### PR TITLE
Add base PHP/Twig structure for root and client

### DIFF
--- a/client_schema.sql
+++ b/client_schema.sql
@@ -1,0 +1,41 @@
+-- SQL schema for client database
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL,
+    password VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE theme (
+    id INT PRIMARY KEY DEFAULT 1,
+    name VARCHAR(50) NOT NULL,
+    version VARCHAR(20) NOT NULL
+);
+
+CREATE TABLE sections (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    module VARCHAR(50) NOT NULL,
+    position INT NOT NULL
+);
+
+CREATE TABLE content_slider (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    image VARCHAR(255),
+    caption TEXT
+);
+
+CREATE TABLE settings (
+    id INT PRIMARY KEY DEFAULT 1,
+    site_title VARCHAR(100),
+    maintenance TINYINT(1) DEFAULT 0
+);
+
+CREATE TABLE custom_css (
+    id INT PRIMARY KEY DEFAULT 1,
+    css TEXT
+);
+
+CREATE TABLE custom_js (
+    id INT PRIMARY KEY DEFAULT 1,
+    js TEXT
+);

--- a/cliente001/.config.php
+++ b/cliente001/.config.php
@@ -1,0 +1,21 @@
+<?php
+// Client specific configuration
+
+define('CLIENT_PATH', __DIR__);
+define('TEMPLATE_PATH', CLIENT_PATH . '/templates');
+
+define('DB_HOST', 'localhost');
+define('DB_USER', 'client');
+define('DB_PASS', 'password');
+define('DB_NAME', 'client_site');
+
+define('SITE_KEY', 'ABC123');
+define('ROOT_VALIDATOR', 'https://rootserver.com/api/validador.php');
+
+function db_connect() {
+    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($mysqli->connect_error) {
+        die('DB Connection failed: ' . $mysqli->connect_error);
+    }
+    return $mysqli;
+}

--- a/cliente001/admin/dashboard.php
+++ b/cliente001/admin/dashboard.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../.config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+if (!($_SESSION['user'] ?? false)) {
+    header('Location: index.php');
+    exit;
+}
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('dashboard.twig');

--- a/cliente001/admin/index.php
+++ b/cliente001/admin/index.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../.config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user = $_POST['user'] ?? '';
+    $pass = $_POST['pass'] ?? '';
+    // Dummy check
+    if ($user === 'client' && $pass === 'client') {
+        $_SESSION['user'] = $user;
+        header('Location: dashboard.php');
+        exit;
+    }
+    $error = 'Invalid login';
+}
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('login.twig', ['error' => $error ?? null]);

--- a/cliente001/admin/templates/dashboard.twig
+++ b/cliente001/admin/templates/dashboard.twig
@@ -1,0 +1,2 @@
+<h1>Client Dashboard</h1>
+<p>Manage your content here.</p>

--- a/cliente001/admin/templates/login.twig
+++ b/cliente001/admin/templates/login.twig
@@ -1,0 +1,6 @@
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+<form method="post">
+    <label>User: <input type="text" name="user"></label><br>
+    <label>Pass: <input type="password" name="pass"></label><br>
+    <button type="submit">Login</button>
+</form>

--- a/cliente001/includes/twig_loader.php
+++ b/cliente001/includes/twig_loader.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+function get_twig($path)
+{
+    $loader = new FilesystemLoader($path);
+    $twig = new Environment($loader);
+    return $twig;
+}

--- a/cliente001/index.php
+++ b/cliente001/index.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/.config.php';
+require_once __DIR__ . '/includes/twig_loader.php';
+
+function is_authorized()
+{
+    $url = ROOT_VALIDATOR . '?site_key=' . urlencode(SITE_KEY);
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    if ($response) {
+        $data = json_decode($response, true);
+        return $data['status'] === 'active';
+    }
+    return false;
+}
+
+if (!is_authorized()) {
+    echo 'Site not authorized';
+    exit;
+}
+
+$twig = get_twig(TEMPLATE_PATH . '/default');
+echo $twig->render('page.twig', ['content' => 'Hello World']);

--- a/cliente001/modules/carousel.twig
+++ b/cliente001/modules/carousel.twig
@@ -1,0 +1,3 @@
+<div class="carousel">
+    <p>Carousel placeholder</p>
+</div>

--- a/cliente001/templates/default/page.twig
+++ b/cliente001/templates/default/page.twig
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Client Site</title>
+</head>
+<body>
+    <h1>{{ content }}</h1>
+    {% include '../../modules/carousel.twig' %}
+</body>
+</html>

--- a/root/admin/dashboard.php
+++ b/root/admin/dashboard.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+if (!($_SESSION['admin'] ?? false)) {
+    header('Location: login.php');
+    exit;
+}
+
+$mysqli = db_connect();
+$result = $mysqli->query('SELECT id, domain, status FROM websites');
+$sites = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('dashboard.twig', ['sites' => $sites]);

--- a/root/admin/login.php
+++ b/root/admin/login.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user = $_POST['user'] ?? '';
+    $pass = $_POST['pass'] ?? '';
+    // Simplified auth - replace with secure check
+    if ($user === 'admin' && $pass === 'admin') {
+        $_SESSION['admin'] = true;
+        header('Location: dashboard.php');
+        exit;
+    }
+    $error = 'Invalid credentials';
+}
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('login.twig', ['error' => $error ?? null]);

--- a/root/admin/templates/dashboard.twig
+++ b/root/admin/templates/dashboard.twig
@@ -1,0 +1,13 @@
+<h1>Websites</h1>
+<table border="1">
+    <tr><th>ID</th><th>Domain</th><th>Status</th></tr>
+    {% for site in sites %}
+    <tr>
+        <td>{{ site.id }}</td>
+        <td>{{ site.domain }}</td>
+        <td>{{ site.status }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="3">No websites</td></tr>
+    {% endfor %}
+</table>

--- a/root/admin/templates/login.twig
+++ b/root/admin/templates/login.twig
@@ -1,0 +1,6 @@
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+<form method="post">
+    <label>User: <input type="text" name="user"></label><br>
+    <label>Pass: <input type="password" name="pass"></label><br>
+    <button type="submit">Login</button>
+</form>

--- a/root/api/validador.php
+++ b/root/api/validador.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../config.php';
+header('Content-Type: application/json');
+
+$siteKey = $_GET['site_key'] ?? '';
+$clientIp = $_SERVER['REMOTE_ADDR'];
+
+$mysqli = db_connect();
+$stmt = $mysqli->prepare('SELECT status, allowed_ip FROM websites WHERE site_key = ?');
+$stmt->bind_param('s', $siteKey);
+$stmt->execute();
+$result = $stmt->get_result();
+if ($row = $result->fetch_assoc()) {
+    if ($row['allowed_ip'] && $row['allowed_ip'] !== $clientIp) {
+        $status = 'blocked';
+    } else {
+        $status = $row['status'];
+    }
+} else {
+    $status = 'unknown';
+}
+
+echo json_encode(['status' => $status]);

--- a/root/config.php
+++ b/root/config.php
@@ -1,0 +1,22 @@
+<?php
+// Global configuration for root server
+
+define('ROOT_PATH', __DIR__);
+
+define('PUBLIC_PATH', ROOT_PATH . '/public');
+define('ADMIN_PATH', ROOT_PATH . '/admin');
+define('API_PATH', ROOT_PATH . '/api');
+
+define('DB_HOST', 'localhost');
+define('DB_USER', 'root');
+define('DB_PASS', 'password');
+define('DB_NAME', 'root_platform');
+
+// Simple function to connect using MySQLi
+function db_connect() {
+    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($mysqli->connect_error) {
+        die('DB Connection failed: ' . $mysqli->connect_error);
+    }
+    return $mysqli;
+}

--- a/root/includes/twig_loader.php
+++ b/root/includes/twig_loader.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+function get_twig($path)
+{
+    $loader = new FilesystemLoader($path);
+    $twig = new Environment($loader);
+    return $twig;
+}

--- a/root/index.php
+++ b/root/index.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/includes/twig_loader.php';
+
+$twig = get_twig(PUBLIC_PATH . '/templates');
+
+echo $twig->render('home.twig');

--- a/root/public/templates/footer.twig
+++ b/root/public/templates/footer.twig
@@ -1,0 +1,5 @@
+<footer>
+    <p>&copy; {{ "now"|date("Y") }} TejoBeta</p>
+</footer>
+</body>
+</html>

--- a/root/public/templates/header.twig
+++ b/root/public/templates/header.twig
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title|default('TejoBeta') }}</title>
+</head>
+<body>
+<header>
+    <h1>TejoBeta</h1>
+    <nav>
+        <a href="/">Home</a>
+    </nav>
+</header>

--- a/root/public/templates/home.twig
+++ b/root/public/templates/home.twig
@@ -1,0 +1,6 @@
+{% include 'header.twig' %}
+<main>
+    <h2>Welcome to TejoBeta</h2>
+    <p>Create and manage your website easily.</p>
+</main>
+{% include 'footer.twig' %}


### PR DESCRIPTION
## Summary
- build root server structure using Twig for landing page
- add admin login and dashboard pages
- implement basic validation API
- scaffold example client site with backoffice
- provide sample SQL schema for client database

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6886796010c08323a2a35916c340a1a8