### PR TITLE
Add contact form and client CSS editor

### DIFF
--- a/client_schema.sql
+++ b/client_schema.sql
@@ -1,0 +1,41 @@
+-- SQL schema for client database
+
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    username VARCHAR(50) NOT NULL,
+    password VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE theme (
+    id INT PRIMARY KEY DEFAULT 1,
+    name VARCHAR(50) NOT NULL,
+    version VARCHAR(20) NOT NULL
+);
+
+CREATE TABLE sections (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    module VARCHAR(50) NOT NULL,
+    position INT NOT NULL
+);
+
+CREATE TABLE content_slider (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    image VARCHAR(255),
+    caption TEXT
+);
+
+CREATE TABLE settings (
+    id INT PRIMARY KEY DEFAULT 1,
+    site_title VARCHAR(100),
+    maintenance TINYINT(1) DEFAULT 0
+);
+
+CREATE TABLE custom_css (
+    id INT PRIMARY KEY DEFAULT 1,
+    css TEXT
+);
+
+CREATE TABLE custom_js (
+    id INT PRIMARY KEY DEFAULT 1,
+    js TEXT
+);

--- a/cliente001/.config.php
+++ b/cliente001/.config.php
@@ -1,0 +1,21 @@
+<?php
+// Client specific configuration
+
+define('CLIENT_PATH', __DIR__);
+define('TEMPLATE_PATH', CLIENT_PATH . '/templates');
+
+define('DB_HOST', 'localhost');
+define('DB_USER', 'client');
+define('DB_PASS', 'password');
+define('DB_NAME', 'client_site');
+
+define('SITE_KEY', 'ABC123');
+define('ROOT_VALIDATOR', 'https://rootserver.com/api/validador.php');
+
+function db_connect() {
+    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($mysqli->connect_error) {
+        die('DB Connection failed: ' . $mysqli->connect_error);
+    }
+    return $mysqli;
+}

--- a/cliente001/admin/dashboard.php
+++ b/cliente001/admin/dashboard.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/../.config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+if (!($_SESSION['user'] ?? false)) {
+    header('Location: index.php');
+    exit;
+}
+
+$mysqli = db_connect();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $css = $_POST['css'] ?? '';
+    $stmt = $mysqli->prepare('UPDATE custom_css SET css=? WHERE id=1');
+    $stmt->bind_param('s', $css);
+    $stmt->execute();
+}
+
+$result = $mysqli->query('SELECT css FROM custom_css WHERE id=1');
+$row = $result->fetch_assoc();
+$css = $row['css'] ?? '';
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('dashboard.twig', ['css' => $css]);

--- a/cliente001/admin/index.php
+++ b/cliente001/admin/index.php
@@ -1,0 +1,19 @@
+<?php
+require_once __DIR__ . '/../.config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user = $_POST['user'] ?? '';
+    $pass = $_POST['pass'] ?? '';
+    // Dummy check
+    if ($user === 'client' && $pass === 'client') {
+        $_SESSION['user'] = $user;
+        header('Location: dashboard.php');
+        exit;
+    }
+    $error = 'Invalid login';
+}
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('login.twig', ['error' => $error ?? null]);

--- a/cliente001/admin/templates/dashboard.twig
+++ b/cliente001/admin/templates/dashboard.twig
@@ -1,0 +1,9 @@
+<h1>Client Dashboard</h1>
+<p>Manage your content here.</p>
+<form method="post">
+    <label>Custom CSS:<br>
+        <textarea name="css" rows="8" cols="60">{{ css }}</textarea>
+    </label><br>
+    <button type="submit">Save</button>
+</form>
+

--- a/cliente001/admin/templates/login.twig
+++ b/cliente001/admin/templates/login.twig
@@ -1,0 +1,6 @@
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+<form method="post">
+    <label>User: <input type="text" name="user"></label><br>
+    <label>Pass: <input type="password" name="pass"></label><br>
+    <button type="submit">Login</button>
+</form>

--- a/cliente001/includes/twig_loader.php
+++ b/cliente001/includes/twig_loader.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+function get_twig($path)
+{
+    $loader = new FilesystemLoader($path);
+    $twig = new Environment($loader);
+    return $twig;
+}

--- a/cliente001/index.php
+++ b/cliente001/index.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/.config.php';
+require_once __DIR__ . '/includes/twig_loader.php';
+
+function is_authorized()
+{
+    $url = ROOT_VALIDATOR . '?site_key=' . urlencode(SITE_KEY);
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $response = curl_exec($ch);
+    curl_close($ch);
+    if ($response) {
+        $data = json_decode($response, true);
+        return $data['status'] === 'active';
+    }
+    return false;
+}
+
+if (!is_authorized()) {
+    echo 'Site not authorized';
+    exit;
+}
+
+$mysqli = db_connect();
+$css = '';
+$result = $mysqli->query('SELECT css FROM custom_css WHERE id=1');
+if ($row = $result->fetch_assoc()) {
+    $css = $row['css'];
+}
+
+$twig = get_twig(TEMPLATE_PATH . '/default');
+echo $twig->render('page.twig', [
+    'content' => 'Hello World',
+    'custom_css' => $css
+]);

--- a/cliente001/modules/carousel.twig
+++ b/cliente001/modules/carousel.twig
@@ -1,0 +1,3 @@
+<div class="carousel">
+    <p>Carousel placeholder</p>
+</div>

--- a/cliente001/templates/default/page.twig
+++ b/cliente001/templates/default/page.twig
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Client Site</title>
+    {% if custom_css %}
+    <style>{{ custom_css|raw }}</style>
+    {% endif %}
+</head>
+<body>
+    <h1>{{ content }}</h1>
+    {% include '../../modules/carousel.twig' %}
+</body>
+</html>

--- a/root/admin/dashboard.php
+++ b/root/admin/dashboard.php
@@ -1,0 +1,16 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+if (!($_SESSION['admin'] ?? false)) {
+    header('Location: login.php');
+    exit;
+}
+
+$mysqli = db_connect();
+$result = $mysqli->query('SELECT id, domain, status FROM websites');
+$sites = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('dashboard.twig', ['sites' => $sites]);

--- a/root/admin/login.php
+++ b/root/admin/login.php
@@ -1,0 +1,21 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $user = $_POST['user'] ?? '';
+    $pass = $_POST['pass'] ?? '';
+    $code = $_POST['code'] ?? '';
+    // Simplified auth and 2FA check
+    if ($user === 'admin' && $pass === 'admin' && $code === ADMIN_2FA_CODE) {
+        $_SESSION['admin'] = true;
+        header('Location: dashboard.php');
+        exit;
+    }
+    $error = 'Invalid credentials or code';
+}
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('login.twig', ['error' => $error ?? null]);

--- a/root/admin/messages.php
+++ b/root/admin/messages.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../includes/twig_loader.php';
+
+session_start();
+if (!($_SESSION['admin'] ?? false)) {
+    header('Location: login.php');
+    exit;
+}
+
+$messages = [];
+$logFile = __DIR__ . '/../data/messages.log';
+if (file_exists($logFile)) {
+    $lines = file($logFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    foreach ($lines as $line) {
+        list($date, $name, $email, $msg) = explode("\t", $line, 4);
+        $messages[] = ['date' => $date, 'name' => $name, 'email' => $email, 'message' => $msg];
+    }
+}
+
+$twig = get_twig(__DIR__ . '/templates');
+echo $twig->render('messages.twig', ['messages' => $messages]);
+

--- a/root/admin/templates/dashboard.twig
+++ b/root/admin/templates/dashboard.twig
@@ -1,0 +1,14 @@
+<h1>Websites</h1>
+<p><a href="messages.php">View contact messages</a></p>
+<table border="1">
+    <tr><th>ID</th><th>Domain</th><th>Status</th></tr>
+    {% for site in sites %}
+    <tr>
+        <td>{{ site.id }}</td>
+        <td>{{ site.domain }}</td>
+        <td>{{ site.status }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="3">No websites</td></tr>
+    {% endfor %}
+</table>

--- a/root/admin/templates/login.twig
+++ b/root/admin/templates/login.twig
@@ -1,0 +1,8 @@
+{% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+<form method="post">
+    <label>User: <input type="text" name="user"></label><br>
+    <label>Pass: <input type="password" name="pass"></label><br>
+    <label>2FA Code: <input type="text" name="code"></label><br>
+    <button type="submit">Login</button>
+</form>
+

--- a/root/admin/templates/messages.twig
+++ b/root/admin/templates/messages.twig
@@ -1,0 +1,15 @@
+<h1>Contact Messages</h1>
+<table border="1">
+    <tr><th>Date</th><th>Name</th><th>Email</th><th>Message</th></tr>
+    {% for m in messages %}
+    <tr>
+        <td>{{ m.date }}</td>
+        <td>{{ m.name }}</td>
+        <td>{{ m.email }}</td>
+        <td>{{ m.message }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="4">No messages</td></tr>
+    {% endfor %}
+</table>
+

--- a/root/api/validador.php
+++ b/root/api/validador.php
@@ -1,0 +1,27 @@
+<?php
+require_once __DIR__ . '/../config.php';
+header('Content-Type: application/json');
+
+$siteKey = $_GET['site_key'] ?? '';
+$clientIp = $_SERVER['REMOTE_ADDR'];
+
+$mysqli = db_connect();
+$stmt = $mysqli->prepare('SELECT status, allowed_ip FROM websites WHERE site_key = ?');
+$stmt->bind_param('s', $siteKey);
+$stmt->execute();
+$result = $stmt->get_result();
+
+if ($row = $result->fetch_assoc()) {
+    if ($row['allowed_ip'] && $row['allowed_ip'] !== $clientIp) {
+        $status = 'blocked';
+    } else {
+        $status = $row['status'];
+    }
+} else {
+    $status = 'unknown';
+}
+
+$logLine = sprintf("%s\t%s\t%s\t%s\n", date('c'), $clientIp, $siteKey, $status);
+file_put_contents(__DIR__ . '/../logs/validador.log', $logLine, FILE_APPEND);
+
+echo json_encode(['status' => $status]);

--- a/root/config.php
+++ b/root/config.php
@@ -1,0 +1,24 @@
+<?php
+// Global configuration for root server
+
+define('ROOT_PATH', __DIR__);
+
+define('PUBLIC_PATH', ROOT_PATH . '/public');
+define('ADMIN_PATH', ROOT_PATH . '/admin');
+define('API_PATH', ROOT_PATH . '/api');
+
+define('DB_HOST', 'localhost');
+define('DB_USER', 'root');
+define('DB_PASS', 'password');
+define('DB_NAME', 'root_platform');
+
+define('ADMIN_2FA_CODE', '123456');
+
+// Simple function to connect using MySQLi
+function db_connect() {
+    $mysqli = new mysqli(DB_HOST, DB_USER, DB_PASS, DB_NAME);
+    if ($mysqli->connect_error) {
+        die('DB Connection failed: ' . $mysqli->connect_error);
+    }
+    return $mysqli;
+}

--- a/root/contact.php
+++ b/root/contact.php
@@ -1,0 +1,23 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/includes/twig_loader.php';
+
+$twig = get_twig(PUBLIC_PATH . '/templates');
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $message = trim($_POST['message'] ?? '');
+    if ($name && $email && $message) {
+        $entry = date('c') . "\t$name\t$email\t" . str_replace(["\r", "\n"], ' ', $message) . "\n";
+        file_put_contents(__DIR__ . '/data/messages.log', $entry, FILE_APPEND);
+        $success = true;
+    } else {
+        $error = 'All fields are required';
+    }
+    echo $twig->render('contact.twig', ['error' => $error ?? null, 'success' => $success ?? false]);
+    return;
+}
+
+echo $twig->render('contact.twig');
+

--- a/root/includes/twig_loader.php
+++ b/root/includes/twig_loader.php
@@ -1,0 +1,12 @@
+<?php
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+use Twig\Loader\FilesystemLoader;
+use Twig\Environment;
+
+function get_twig($path)
+{
+    $loader = new FilesystemLoader($path);
+    $twig = new Environment($loader);
+    return $twig;
+}

--- a/root/index.php
+++ b/root/index.php
@@ -1,0 +1,7 @@
+<?php
+require_once __DIR__ . '/config.php';
+require_once __DIR__ . '/includes/twig_loader.php';
+
+$twig = get_twig(PUBLIC_PATH . '/templates');
+
+echo $twig->render('home.twig');

--- a/root/public/templates/contact.twig
+++ b/root/public/templates/contact.twig
@@ -1,0 +1,18 @@
+{% include 'header.twig' %}
+<main>
+    <h2>Contact Us</h2>
+    {% if success %}
+        <p style="color:green">Message sent!</p>
+    {% else %}
+        {% if error %}<p style="color:red">{{ error }}</p>{% endif %}
+        <form method="post" action="/contact.php">
+            <label>Name: <input type="text" name="name"></label><br>
+            <label>Email: <input type="email" name="email"></label><br>
+            <label>Message:<br><textarea name="message" rows="4" cols="40"></textarea></label><br>
+            <button type="submit">Send</button>
+        </form>
+    {% endif %}
+</main>
+{% include 'footer.twig' %}
+
+

--- a/root/public/templates/footer.twig
+++ b/root/public/templates/footer.twig
@@ -1,0 +1,5 @@
+<footer>
+    <p>&copy; {{ "now"|date("Y") }} TejoBeta</p>
+</footer>
+</body>
+</html>

--- a/root/public/templates/header.twig
+++ b/root/public/templates/header.twig
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ title|default('TejoBeta') }}</title>
+</head>
+<body>
+<header>
+    <h1>TejoBeta</h1>
+    <nav>
+        <a href="/">Home</a> |
+        <a href="/contact.php">Contact</a>
+    </nav>
+</header>

--- a/root/public/templates/home.twig
+++ b/root/public/templates/home.twig
@@ -1,0 +1,7 @@
+{% include 'header.twig' %}
+<main>
+    <h2>Welcome to TejoBeta</h2>
+    <p>Create and manage your website easily.</p>
+    <p><a href="/contact.php">Contact us</a> for more information.</p>
+</main>
+{% include 'footer.twig' %}


### PR DESCRIPTION
## Summary
- add contact page with form and message logging
- display contact messages in new admin page
- log API requests to validador log
- implement simple 2FA check for admin login
- allow client site to save custom CSS via dashboard

## Testing
- `php -l` on all PHP files

------
https://chatgpt.com/codex/tasks/task_e_6886796010c08323a2a35916c340a1a8